### PR TITLE
fix typos, doc formatting

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -108,7 +108,7 @@
    "outputs": [],
    "source": [
     "H = editor2.get_graph()\n",
-    "H == G and not H is G"
+    "H == G and H is not G"
    ]
   },
   {
@@ -160,7 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The graph drawn above is bipartite and the partition numbe of a vertex is the first coordinate of its label. The code below sorts and colors vertices according to their partition number and changes their size according to the second coordinate of their label."
+    "The graph drawn above is bipartite and the partition number of a vertex is the first coordinate of its label. The code below sorts and colors vertices according to their partition number and changes their size according to the second coordinate of their label."
    ]
   },
   {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,8 +30,6 @@ except ImportError:
     raise RuntimeError("to build the documentation you need to be inside a Sage shell (run first the command 'sage -sh' in a shell")
 
 
-
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -146,7 +144,6 @@ source_suffix = '.rst'
 
 # The master toctree document.
 master_doc = 'index'
-
 
 
 # The version info for the project you're documenting, acts as replacement for
@@ -395,17 +392,19 @@ if (os.environ.get('SAGE_DOC_MATHJAX', 'no') != 'no'
     html_static_path.append(SAGE_SHARE + "/mathjax")  # sage distribution
     html_static_path.append(SAGE_LOCAL + "/lib/mathjax")    # conda
 else:
-     extensions.append('sphinx.ext.imgmath')
+    extensions.append('sphinx.ext.imgmath')
 
 # This is to make the verbatim font smaller;
 # Verbatim environment is not breaking long lines
 from sphinx.highlighting import PygmentsBridge
 from pygments.formatters.latex import LatexFormatter
 
+
 class CustomLatexFormatter(LatexFormatter):
     def __init__(self, **options):
         super(CustomLatexFormatter, self).__init__(**options)
         self.verboptions = r"formatcom=\footnotesize"
+
 
 PygmentsBridge.latex_formatter = CustomLatexFormatter
 

--- a/src/phitigra/graph_editor.py
+++ b/src/phitigra/graph_editor.py
@@ -829,7 +829,7 @@ class GraphEditor():
 
         TESTS:
 
-        Same as in :meth:`get_vertex_pos` ::
+        Same as in :meth:`get_vertex_pos`::
 
             sage: from phitigra import GraphEditor
             sage: ed = GraphEditor(Graph(1))

--- a/src/phitigra/graph_editor.py
+++ b/src/phitigra/graph_editor.py
@@ -153,7 +153,7 @@ class GraphEditor():
 
         No output, only side effects. Draws an arrow on the canvas.
 
-        TESTS::
+        TESTS:
 
         A dummy test, for this drawing function can hardly be tested::
 
@@ -827,9 +827,9 @@ class GraphEditor():
 
             This function does not redraw the graph.
 
-        TESTS::
+        TESTS:
 
-        Same as in :meth:`get_vertex_pos`.
+        Same as in :meth:`get_vertex_pos` ::
 
             sage: from phitigra import GraphEditor
             sage: ed = GraphEditor(Graph(1))
@@ -942,10 +942,11 @@ class GraphEditor():
 
 
         .. WARNING::
-            This function assumes that edges are straigh lines between
+
+            This function assumes that edges are straight lines between
             their endpoints.
 
-        EXAMPLES:
+        EXAMPLES::
 
             sage: from phitigra import GraphEditor
             sage: ed = GraphEditor(graphs.PathGraph(3))
@@ -1290,7 +1291,7 @@ class GraphEditor():
         :meth:`~GraphEditor.`get_vertex_color`.
         If ``highlight`` is true, also draw the focus on ``v``.
 
-        TESTS::
+        TESTS:
 
         A dummy test, for this drawing function can hardly be tested::
 
@@ -1335,7 +1336,7 @@ class GraphEditor():
         """
         Draw the edges incident to a vertex.
 
-        TESTS::
+        TESTS:
 
         A dummy test, for this drawing function can hardly be tested::
 
@@ -1369,9 +1370,9 @@ class GraphEditor():
 
         .. WARNING::
 
-        - The function does not check that ``e`` is an edge of ``self``;
+            The function does not check that ``e`` is an edge of ``self``;
 
-        TESTS::
+        TESTS:
 
         A dummy test, for this drawing function can hardly be tested::
 
@@ -1496,7 +1497,7 @@ class GraphEditor():
 
         .. WARNING::
 
-        No check is done that `vertex` indeed is a vertex of the graph.
+            No check is done that `vertex` indeed is a vertex of the graph.
 
         TESTS::
 
@@ -1606,7 +1607,7 @@ class GraphEditor():
         - otherwise, the click was done on the canvas: record its position
           in order to later move the drawing when the mouse is moved.
 
-        TESTS::
+        TESTS:
 
         A dummy test, for this function can hardly be tested::
 
@@ -1975,8 +1976,8 @@ class GraphEditor():
         This function is called when a down click is done on the canvas.
         Depending on the current tool in use, call the appropriate function.
 
-
         INPUT:
+
         - ``click_x``, ``click_y`` -- integers;
           the coordinates of the click.
 
@@ -1984,7 +1985,7 @@ class GraphEditor():
 
         No output, just a call to the appropriate function.
 
-        TESTS::
+        TESTS:
 
         A dummy test, for this function can hardly be tested::
 
@@ -2026,6 +2027,7 @@ class GraphEditor():
         Depending on the current tool in use, call the appropriate function.
 
         INPUT:
+
         - ``click_x``, ``click_y`` -- integers;
           the coordinates of the mouse.
 
@@ -2033,7 +2035,7 @@ class GraphEditor():
 
         No output, just a call to the appropriate function.
 
-        TESTS::
+        TESTS:
 
         A dummy test, for this function can hardly be tested::
 
@@ -2073,6 +2075,7 @@ class GraphEditor():
         Depending on the current tool in use, call the appropriate function.
 
         INPUT:
+
         - ``click_x``, ``click_y`` -- integers;
           the coordinates of the click.
 
@@ -2080,7 +2083,7 @@ class GraphEditor():
 
         No output, just a call to the appropriate function.
 
-        TESTS::
+        TESTS:
 
         A dummy test, for this function can hardly be tested::
 


### PR DESCRIPTION
correction de quelques typos

correction de la syntaxe rst de la doc

un peu de style dans le code (ruff et pycodestyle)